### PR TITLE
raise exception for status=error but no error_type in response

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -876,13 +876,13 @@ class KiteConnect(object):
                     content=r.content))
 
             # api error
-            if data.get("error_type"):
+            if data.get("status") == "error" or data.get("error_type"):
                 # Call session hook if its registered and TokenException is raised
                 if self.session_expiry_hook and r.status_code == 403 and data["error_type"] == "TokenException":
                     self.session_expiry_hook()
 
                 # native Kite errors
-                exp = getattr(ex, data["error_type"], ex.GeneralException)
+                exp = getattr(ex, data.get("error_type"), ex.GeneralException)
                 raise exp(data["message"], code=r.status_code)
 
             return data["data"]


### PR DESCRIPTION
Request:
`curl "https://api.kite.trade/mf/orders" -H "X-Kite-Version: 3" -H "Authorization: token <api_key>:<access_token>" -d "tradingsymbol=INF174K01LSS" -d "transaction_type=BUY" -d "amount=1000"`
Response:
```{"status":"error","message":"Invalid `isin`","data":{}}```

I think it would be great if there were an error_type with this response so that an exception is raised in case of an invalid payload with some information with what went wrong. I also noticed similar behaviour with `/mf/sips` and a few other apis. This should hopefully help work around that.