### PR TITLE
Adds required variety parameter in place_order

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ try:
                                 exchange=kite.EXCHANGE_NSE,
                                 transaction_type=kite.TRANSACTION_TYPE_BUY,
                                 quantity=1,
+                                variety=kite.VARIETY_AMO,
                                 order_type=kite.ORDER_TYPE_MARKET,
                                 product=kite.PRODUCT_NRML)
 


### PR DESCRIPTION
`variety` seems to be a mandatory parameter but it isn't used in the "Getting Started" example in the `README.md`