### PR TITLE
feat: add tz info to all naive datetime object

### DIFF
--- a/examples/order_margins.py
+++ b/examples/order_margins.py
@@ -62,6 +62,9 @@ try:
 
     margin_detail = kite.order_margins(order_param_multi)
     logging.info("Required margin for order_list: {}".format(margin_detail))
+    # Compact margin response
+    margin_detail_compt = kite.basket_order_margins(order_param_multi, mode='compact')
+    logging.info("Required margin for order_list in compact form: {}".format(margin_detail_compt))
 
     # Basket orders
     order_param_basket = [


### PR DESCRIPTION
1> Add IST timezone info to all naive DateTime objects. 
Eg: `'order_timestamp': datetime.datetime(2021, 7, 1, 16, 45, 36, tzinfo=tzoffset('Asia/Kolkata', 19800)), 'exchange_timestamp': datetime.datetime(2021, 7, 1, 16, 45, 36, tzinfo=tzoffset('Asia/Kolkata', 19800)`
2> Introduce proper logic(`is_timestamp`) to check if the response string is a timestamp field. Give away with an earlier string length comparison.
3> Add optional `mode` field for order_margins.
4> Add example with mode param for order_margins.