### PR TITLE
Replaced urljoin function in favour of Concatenation

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -8,7 +8,6 @@
     :license: see LICENSE for details.
 """
 from six import StringIO, PY2
-from six.moves.urllib.parse import urljoin
 import csv
 import json
 import dateutil.parser
@@ -855,7 +854,7 @@ class KiteConnect(object):
         else:
             uri = self._routes[route]
 
-        url = urljoin(self.root, uri)
+        url = self.root + uri
 
         # Custom headers
         headers = {


### PR DESCRIPTION
urljoin produced un-intuitive joins
for example 

```
from urllib.parse import urljoin

>>> urljoin('some', 'thing')
'thing'
>>> urljoin('http://some', 'thing')
'http://some/thing'
>>> urljoin('http://some/more', 'thing')
'http://some/thing'
>>> urljoin('http://some/more/', 'thing') # just a / after 'more'
'http://some/more/thing'
urljoin('http://some/more/', '/thing')
'http://some/thing'
```

to simplify the final URL generation process, it is proposed 
to replaced urljoin with simple string concatenation