### PR TITLE
chores: add GTT order examples

### DIFF
--- a/examples/gtt_order.py
+++ b/examples/gtt_order.py
@@ -1,0 +1,56 @@
+import logging
+from kiteconnect import KiteConnect
+
+logging.basicConfig(level=logging.DEBUG)
+
+kite = KiteConnect(api_key="your_api_key")
+
+# Redirect the user to the login url obtained
+# from kite.login_url(), and receive the request_token
+# from the registered redirect url after the login flow.
+# Once you have the request_token, obtain the access_token
+# as follows.
+
+data = kite.generate_session("request_token_here", secret="your_secret")
+kite.set_access_token(data["access_token"])
+
+# Place single-leg gtt order - https://kite.trade/docs/connect/v3/gtt/#single
+try:
+    order_single = [{
+        "exchange":"NSE",
+        "tradingsymbol": "SBIN",
+        "transaction_type": kite.TRANSACTION_TYPE_BUY,
+        "quantity": 1,
+        "order_type": "LIMIT",
+        "product": "CNC",
+        "price": 470,
+    }]
+    single_gtt = kite.place_gtt(trigger_type=kite.GTT_TYPE_SINGLE, tradingsymbol="SBIN", exchange="NSE", trigger_values=[470], last_price=473, orders=order_single)
+    logging.info("single leg gtt order trigger_id : {}".format(single_gtt['trigger_id']))
+except Exception as e:
+    logging.info("Error placing single leg gtt order: {}".format(e))
+
+
+# Place two-leg(OCO) gtt order - https://kite.trade/docs/connect/v3/gtt/#two-leg
+try:
+    order_oco = [{
+        "exchange":"NSE",
+        "tradingsymbol": "SBIN",
+        "transaction_type": kite.TRANSACTION_TYPE_SELL,
+        "quantity": 1,
+        "order_type": "LIMIT",
+        "product": "CNC",
+        "price": 470
+        },{
+        "exchange":"NSE",
+        "tradingsymbol": "SBIN",
+        "transaction_type": kite.TRANSACTION_TYPE_SELL,
+        "quantity": 1,
+        "order_type": "LIMIT",
+        "product": "CNC",
+        "price": 480
+    }]
+    gtt_oco = kite.place_gtt(trigger_type=kite.GTT_TYPE_OCO, tradingsymbol="SBIN", exchange="NSE", trigger_values=[470,480], last_price=473, orders=order_oco)
+    logging.info("GTT OCO trigger_id : {}".format(gtt_oco['trigger_id']))
+except Exception as e:
+    logging.info("Error placing gtt oco order: {}".format(e))

--- a/kiteconnect/ticker.py
+++ b/kiteconnect/ticker.py
@@ -271,15 +271,15 @@ class KiteTicker(object):
         [{
             'instrument_token': 53490439,
             'mode': 'full',
-            'volume': 12510,
+            'volume_traded': 12510,
             'last_price': 4084.0,
-            'average_price': 4086.55,
-            'last_quantity': 1,
-            'buy_quantity': 2356
-            'sell_quantity': 2440,
+            'average_traded_price': 4086.55,
+            'last_traded_quantity': 1,
+            'total_buy_quantity': 2356
+            'total_sell_quantity': 2440,
             'change': 0.46740467404674046,
             'last_trade_time': datetime.datetime(2018, 1, 15, 13, 16, 54),
-            'timestamp': datetime.datetime(2018, 1, 15, 13, 16, 56),
+            'exchange_timestamp': datetime.datetime(2018, 1, 15, 13, 16, 56),
             'oi': 21845,
             'oi_day_low': 0,
             'oi_day_high': 0,


### PR DESCRIPTION
1. Add single leg and OCO(two-leg) GTT order example.
2. Update ticker structure sample response in the[ documentation](https://kite.trade/docs/pykiteconnect/v4/#kiteconnect.KiteTicker). 