### PR TITLE
fix: gracefully exit websocket for exceeding max retry attempts

### DIFF
--- a/kiteconnect/ticker.py
+++ b/kiteconnect/ticker.py
@@ -103,7 +103,8 @@ class KiteTickerClientProtocol(WebSocketClientProtocol):
     """
     Custom helper and exposed methods.
     """
-    def _loop_ping(self): # noqa
+
+    def _loop_ping(self):  # noqa
         """Start a ping loop where it sends ping message every X seconds."""
         if self.factory.debug:
             log.debug("ping => {}".format(self._ping_message))
@@ -197,6 +198,8 @@ class KiteTickerClientFactory(WebSocketClientFactory, ReconnectingClientFactory)
         if self.maxRetries is not None and (self.retries > self.maxRetries):
             if self.debug:
                 log.debug("Maximum retries ({}) exhausted.".format(self.maxRetries))
+                # Stop the loop for exceeding max retry attempts
+                self.stop()
 
             if self.on_noreconnect:
                 self.on_noreconnect()
@@ -594,7 +597,7 @@ class KiteTicker(object):
 
             for token in instrument_tokens:
                 try:
-                    del(self.subscribed_tokens[token])
+                    del (self.subscribed_tokens[token])
                 except KeyError:
                     pass
 
@@ -761,7 +764,7 @@ class KiteTicker(object):
 
                 # Compute the change price using close price and last price
                 d["change"] = 0
-                if(d["ohlc"]["close"] != 0):
+                if (d["ohlc"]["close"] != 0):
                     d["change"] = (d["last_price"] - d["ohlc"]["close"]) * 100 / d["ohlc"]["close"]
 
                 # Full mode with timestamp
@@ -798,7 +801,7 @@ class KiteTicker(object):
 
                 # Compute the change price using close price and last price
                 d["change"] = 0
-                if(d["ohlc"]["close"] != 0):
+                if (d["ohlc"]["close"] != 0):
                     d["change"] = (d["last_price"] - d["ohlc"]["close"]) * 100 / d["ohlc"]["close"]
 
                 # Parse full mode


### PR DESCRIPTION
Gracefully exit the websocket once maximum retry attempts is exhausted.