### PR TITLE
feat: add py version 3.9 and 3.10 to tests

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 pytest>=4.6.11
 responses>=0.12.1
 pytest-cov>=2.10.1
-flake8>=3.8.4
+flake8>=3.8.4, <= 4.0.1
 mock>=3.0.5


### PR DESCRIPTION
Include the latest python versions 3.9 and 3.10 to the workflow.