### PR TITLE
fix: initialize ws object in KiteTicker class

### DIFF
--- a/kiteconnect/ticker.py
+++ b/kiteconnect/ticker.py
@@ -452,6 +452,9 @@ class KiteTicker(object):
         # Debug enables logs
         self.debug = debug
 
+        # Initialize default value for websocket object
+        self.ws = None
+
         # Placeholders for callbacks.
         self.on_ticks = None
         self.on_open = None


### PR DESCRIPTION
  Initialize ws object in KiteTicker class, to avoid AttributeError for `is_connected` and `_close` method calls. 