### PR TITLE
fix: link correctly to kite.trade

### DIFF
--- a/kiteconnect/__init__.py
+++ b/kiteconnect/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Kite Connect API client for Python -- [https://kite.trade](kite.trade).
+Kite Connect API client for Python -- [kite.trade](https://kite.trade).
 
 Zerodha Technology Pvt. Ltd. (c) 2021
 


### PR DESCRIPTION
`[text](link)`, not `[link](text)`. Gets us all the time.