### PR TITLE
feat: create session object by default

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-20.04", "windows-latest"]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
         exclude:
           - os: windows-latest
@@ -44,12 +44,12 @@ jobs:
 
       # Build and publish if its a new tag and use latest Python version to push dists
       - name: Build
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'
         run: |
           python setup.py sdist bdist_wheel
 
       - name: Publish package to TestPyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'
         uses: pypa/gh-action-pypi-publish@master
         with:
           verbose: true

--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -209,14 +209,12 @@ class KiteConnect(object):
         self.root = root or self._default_root_uri
         self.timeout = timeout or self._default_timeout
 
-        # Create requests session only if pool exists. Reuse session
-        # for every request. Otherwise create session for each request
+        # Create requests session by default
+        # Same session to be used by pool connections
+        self.reqsession = requests.Session()
         if pool:
-            self.reqsession = requests.Session()
             reqadapter = requests.adapters.HTTPAdapter(**pool)
             self.reqsession.mount("https://", reqadapter)
-        else:
-            self.reqsession = requests
 
         # disable requests SSL warning
         requests.packages.urllib3.disable_warnings()

--- a/tests/unit/test_kite_object.py
+++ b/tests/unit/test_kite_object.py
@@ -25,7 +25,7 @@ class TestKiteConnectObject:
         assert kiteconnect.login_url() == "https://kite.zerodha.com/connect/login?api_key=<API-KEY>&v=3"
 
     def test_request_without_pooling(self, kiteconnect):
-        assert isinstance(kiteconnect.reqsession, requests.Session) is False
+        assert isinstance(kiteconnect.reqsession, requests.Session) is True
         assert kiteconnect.reqsession.request is not None
 
     def test_request_pooling(self, kiteconnect_with_pooling):


### PR DESCRIPTION
This PR introduces below changes:
1. Create requests session object by default for connection reuse.
2. Fix unit tests related to the above changes.
3. Update gitlab CI file to use ubuntu-20.04 instead of ubuntu-latest because of [this workflow error](https://github.com/zerodha/pykiteconnect/actions/runs/3547545557/jobs/5957781913#step:4:7).