### PR TITLE
feat: using github page for docs and automate doc update pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  # This is a separate job so that only deploy-pages has the necessary permissions.
+  deploy:
+    runs-on: ubuntu-20.04
+    permissions:
+      pages: write
+      id-token: write
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pdoc
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools
+          pip install --upgrade wheel
+          pip install pdoc
+          pip install -r dev_requirements.txt
+          pip install -e .
+
+      - name: Build
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          verbose: true
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      # Build documentation into docs/
+      - name: Building documentation for github page
+        run: pdoc -o docs kiteconnect
+
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint/Test
+name: Test
 on: [push, pull_request]
 
 jobs:
@@ -41,17 +41,3 @@ jobs:
       - name: Test with pytest
         run: |
           py.test --cov=./
-
-      # Build and publish if its a new tag and use latest Python version to push dists
-      - name: Build
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'
-        run: |
-          python setup.py sdist bdist_wheel
-
-      - name: Publish package to TestPyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          verbose: true
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
- Implemented a new `Deploy` workflow exclusively for releasing and deployment
- Utilized gh-pages for documentation
- Automated updating of documentation with each new release

Sample doc can be referred here:  http://ranjanrak.github.io/pykiteconnect/