### PR TITLE
fix: downgrade urllib3 version to support openSSL in workflow

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,3 +3,4 @@ responses>=0.12.1
 pytest-cov>=2.10.1
 flake8>=3.8.4, <= 4.0.1
 mock>=3.0.5
+urllib3<2.0

--- a/kiteconnect/ticker.py
+++ b/kiteconnect/ticker.py
@@ -32,7 +32,6 @@ class KiteTickerClientProtocol(WebSocketClientProtocol):
     PING_INTERVAL = 2.5
     KEEPALIVE_INTERVAL = 5
 
-    _ping_message = ""
     _next_ping = None
     _next_pong_check = None
     _last_pong_time = None
@@ -107,14 +106,11 @@ class KiteTickerClientProtocol(WebSocketClientProtocol):
     def _loop_ping(self):  # noqa
         """Start a ping loop where it sends ping message every X seconds."""
         if self.factory.debug:
-            log.debug("ping => {}".format(self._ping_message))
             if self._last_ping_time:
                 log.debug("last ping was {} seconds back.".format(time.time() - self._last_ping_time))
 
         # Set current time as last ping time
         self._last_ping_time = time.time()
-        # Send a ping message to server
-        self.sendPing(self._ping_message)
 
         # Call self after X seconds
         self._next_ping = self.factory.reactor.callLater(self.PING_INTERVAL, self._loop_ping)


### PR DESCRIPTION
- Remove [sendPing](https://github.com/crossbario/autobahn-python/blob/359f868f9db410586cf01c071220994d8d7f165a/autobahn/websocket/interfaces.py#L572) overide in websocket for ping.
- [Force install urllib3<2.0](https://github.com/psf/requests/issues/6432#issuecomment-1535149114) to support openSSL in workflow