### PR TITLE
Fixes #213: fixes 404 not found issue by replacing v1 with v3

### DIFF
--- a/examples/flask_app.py
+++ b/examples/flask_app.py
@@ -64,7 +64,7 @@ login_template = """
     <pre>{user_data}</pre>
     <a target="_blank" href="/holdings.json"><h4>Fetch user holdings</h4></a>
     <a target="_blank" href="/orders.json"><h4>Fetch user orders</h4></a>
-    <a target="_blank" href="https://kite.trade/docs/connect/v1/"><h4>Checks Kite Connect docs for other calls.</h4></a>"""
+    <a target="_blank" href="https://kite.trade/docs/connect/v3/"><h4>Checks Kite Connect docs for other calls.</h4></a>"""
 
 
 def get_kite_client():


### PR DESCRIPTION
## Related Issue
Fixes #213

### Bug Description

"https://kite.trade/docs/connect/v1/"  
The above URL is giving 404 error

### Fix
Replaced with
   ##@"https://kite.trade/docs/connect/v3/"
