### PR TITLE
ci: add GitHub release docs workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+  DOCS_ASSET_NAME: pykiteconnect-docs.tar.gz
+
 jobs:
   release-docs:
     runs-on: ubuntu-22.04
@@ -31,7 +34,7 @@ jobs:
 
       - name: Package docs
         run: |
-          tar -C docs -czf pykiteconnect-docs-${{ github.event.release.tag_name }}.tar.gz kiteconnect
+          tar -C docs -czf "$DOCS_ASSET_NAME" kiteconnect
 
       - name: Attach docs to GitHub release
         env:
@@ -39,5 +42,5 @@ jobs:
         run: |
           gh release upload \
             "${{ github.event.release.tag_name }}" \
-            "pykiteconnect-docs-${{ github.event.release.tag_name }}.tar.gz" \
+            "$DOCS_ASSET_NAME" \
             --clobber

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,43 @@
+name: Release docs
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+
+      - name: Set up Python 3.8 for pdoc 0.3.2
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Build docs
+        run: |
+          pip install pdoc==0.3.2
+          pip install .
+          pdoc --html --html-dir docs kiteconnect
+          test -s docs/kiteconnect/index.html
+
+      - name: Package docs
+        run: |
+          tar -C docs -czf pykiteconnect-docs-${{ github.event.release.tag_name }}.tar.gz kiteconnect
+
+      - name: Attach docs to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload \
+            "${{ github.event.release.tag_name }}" \
+            "pykiteconnect-docs-${{ github.event.release.tag_name }}.tar.gz" \
+            --clobber

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -20,21 +20,22 @@ jobs:
         with:
           ref: refs/tags/${{ github.event.release.tag_name }}
 
-      - name: Set up Python 3.8 for pdoc 0.3.2
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Build docs
         run: |
-          pip install pdoc==0.3.2
+          pip install pdoc==16.0.0
           pip install .
-          pdoc --html --html-dir docs kiteconnect
-          test -s docs/kiteconnect/index.html
+          pdoc -o docs ./kiteconnect
+          test -s docs/index.html
+          test -s docs/kiteconnect.html
 
       - name: Package docs
         run: |
-          tar -C docs -czf "$DOCS_ASSET_NAME" kiteconnect
+          tar -czf "$DOCS_ASSET_NAME" -C docs .
 
       - name: Attach docs to GitHub release
         env:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs when a GitHub release is published
- build `kiteconnect` docs with `pdoc==16.0.0`
- attach a standardized release asset named `pykiteconnect-docs.tar.gz`

## What this changes
This moves release docs generation away from the internal `pykiteconnect-docs` pipeline and keeps the generated docs attached to the GitHub release that triggered them.

Because the asset name is fixed, consumers can use a stable latest-release URL:
- `https://github.com/zerodha/pykiteconnect/releases/latest/download/pykiteconnect-docs.tar.gz`

The archive now contains the full generated site output from modern `pdoc`, including `index.html` at the archive root.

## Notes
- the workflow checks out the exact release tag before building docs
- Python 3.12 is used for the release docs job
- `pdoc` is updated from the legacy `0.3.2` version to `16.0.0`
- internal S3 upload and sync steps are intentionally not carried over

## Validation
- reproduced the workflow steps locally in `python:3.12-slim`
- confirmed docs generation creates `docs/index.html` and `docs/kiteconnect.html`
- confirmed packaging creates `pykiteconnect-docs.tar.gz`
- tested end-to-end on the fork by publishing releases and verifying that:
  - the workflow succeeds
  - the release gets the `pykiteconnect-docs.tar.gz` asset
  - `/releases/latest/download/pykiteconnect-docs.tar.gz` resolves to the newest release asset
  - the downloaded archive contains the generated site root, including `index.html`
